### PR TITLE
docs - java testng - fixing link to examples-java-testng

### DIFF
--- a/docs/log-data-in-reportportal/test-framework-integration/Java/TestNG.md
+++ b/docs/log-data-in-reportportal/test-framework-integration/Java/TestNG.md
@@ -28,4 +28,4 @@ TestNG agent can handle next events:
 
 [Installation guide](https://github.com/reportportal/agent-java-testNG#readme)
 
-[Examples](https://github.com/reportportal/example-java-TestNG)
+[Examples](https://github.com/reportportal/examples-java/tree/master/example-testng-fork-execution)


### PR DESCRIPTION
Fixing Examples link which is broken pointing to:
https://github.com/reportportal/example-java-TestNG

Reference: https://reportportal.io/docs/log-data-in-reportportal/test-framework-integration/Java/TestNG