### PR TITLE
Update file paths in API and UAT sidebars for versioning

### DIFF
--- a/docs/api/versioned_sidebars/api-sidebars.ts
+++ b/docs/api/versioned_sidebars/api-sidebars.ts
@@ -50,7 +50,7 @@ const apiSidebars: SidebarsConfig = {
         description: 'This is a generated index of the ReportPortal Authtorization API.',
         slug: '/category/api/service-api-5.10'
       },
-      items: require('../service-api/5.10/sidebar.ts')
+      items: require('../service-api/versions/5.10/sidebar.ts')
     }
   ],
 };

--- a/docs/api/versioned_sidebars/uat-sidebars.ts
+++ b/docs/api/versioned_sidebars/uat-sidebars.ts
@@ -50,7 +50,7 @@ const uatSidebars: SidebarsConfig = {
         description: 'This is a generated index of the ReportPortal Authtorization API.',
         slug: '/category/api/service-uat-5.10'
       },
-      items: require('../service-uat/5.10/sidebar.ts')
+      items: require('../service-uat/versions/5.10/sidebar.ts')
     }
   ],
 }

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -251,7 +251,7 @@ const config = {
             versions: {
               '5.10': {
                 specPath: 'apis/5.10/service-api.yaml',
-                outputDir: 'docs/api/service-api/5.10',
+                outputDir: 'docs/api/service-api/versions/5.10',
                 label: 'v5.10',
                 baseUrl: `${baseUrl}category/api/service-api-5.10`,
               },
@@ -270,7 +270,7 @@ const config = {
             versions: {
               '5.10': {
                 specPath: 'apis/5.10/service-uat.yaml',
-                outputDir: 'docs/api/service-uat/5.10',
+                outputDir: 'docs/api/service-uat/versions/5.10',
                 label: 'v5.10',
                 baseUrl: `${baseUrl}category/api/service-uat-5.10`,
               },


### PR DESCRIPTION
All old versions are stored in the `/versions` folder.