### PR TITLE
Update JUnit.mdx plugin name to lowercase in endpoint

### DIFF
--- a/docs/plugins/JUnit.mdx
+++ b/docs/plugins/JUnit.mdx
@@ -60,7 +60,7 @@ If the XML file is not in the JUnit structure, the system will interrupt the pro
 JUnit plugin should be enabled.
 :::
 
-The endpoint ```POST /v1/plugin/{projectName}/JUnit/import``` allows importing a launch into the specified project using an XML or ZIP file.
+The endpoint ```POST /v1/plugin/{projectName}/junit/import``` allows importing a launch into the specified project using an XML or ZIP file.
 
 You can configure parameters (name, description, attributes) for the imported launch by specifying these values in your API request.
 


### PR DESCRIPTION
The api endpoint is case sensitive and only works with lowercase for me otherwise I get an error: "Error in handled Request. Please, check specified parameters: 'Plugin for 'jUnit' isn't installed'"