### PR TITLE
EPMRPP-118655 || Automate Algolia Crawler for documentation search

### DIFF
--- a/.github/workflows/deploy-prod-aws.yml
+++ b/.github/workflows/deploy-prod-aws.yml
@@ -55,6 +55,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [clean-docs-folder]
     environment: production
+    outputs:
+      amplify_job_id: ${{ steps.amplify.outputs.job_id }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -90,6 +92,7 @@ jobs:
         run: aws s3 sync ./${{ env.BUILD_DIR }} s3://${{ env.AWS_S3_BUCKET_NAME }}/docs/
 
       - name: Trigger Amplify redeploy
+        id: amplify
         run: |
           aws s3 sync s3://${{ env.AWS_S3_BUCKET_NAME }} /tmp/full-site
 
@@ -109,6 +112,74 @@ jobs:
             --app-id ${{ secrets.AWS_AMPLIFY_APP_ID }} \
             --branch-name production \
             --job-id "$JOB_ID"
+
+          echo "job_id=${JOB_ID}" >> "$GITHUB_OUTPUT"
+
+  wait-amplify:
+    needs: deploy
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION_NAME }}
+
+      - name: Wait for Amplify deployment
+        env:
+          AWS_AMPLIFY_APP_ID: ${{ secrets.AWS_AMPLIFY_APP_ID }}
+          AMPLIFY_JOB_ID: ${{ needs.deploy.outputs.amplify_job_id }}
+        run: |
+          TIMEOUT_SECONDS=900
+          INTERVAL_SECONDS=15
+          elapsed=0
+
+          while [ "$elapsed" -lt "$TIMEOUT_SECONDS" ]; do
+            STATUS=$(aws amplify get-job \
+              --app-id "${AWS_AMPLIFY_APP_ID}" \
+              --branch-name production \
+              --job-id "${AMPLIFY_JOB_ID}" \
+              --query 'job.summary.status' \
+              --output text)
+
+            echo "Amplify job ${AMPLIFY_JOB_ID} status: ${STATUS} (${elapsed}s)"
+
+            case "${STATUS}" in
+              SUCCEED)
+                echo "Amplify deployment succeeded."
+                exit 0
+                ;;
+              FAILED|CANCELLED|CANCELLING)
+                echo "::error::Amplify deployment ${STATUS}."
+                exit 1
+                ;;
+            esac
+
+            sleep "${INTERVAL_SECONDS}"
+            elapsed=$((elapsed + INTERVAL_SECONDS))
+          done
+
+          echo "::error::Timed out waiting for Amplify job ${AMPLIFY_JOB_ID}."
+          exit 1
+
+  start-algolia-crawler:
+    needs: wait-amplify
+    runs-on: ubuntu-latest
+    environment: production
+    continue-on-error: true
+    steps:
+      - name: Start Algolia crawler reindex
+        env:
+          USER_ID: ${{ secrets.ALGOLIA_CRAWLER_USER_ID }}
+          API_KEY: ${{ secrets.ALGOLIA_CRAWLER_API_KEY }}
+          CRAWLER_ID: ${{ secrets.ALGOLIA_CRAWLER_ID }}
+        run: |
+          CREDENTIALS=$(printf '%s' "${USER_ID}:${API_KEY}" | base64 -w 0)
+
+          curl --fail-with-body -X POST \
+            -H "Authorization: Basic ${CREDENTIALS}" \
+            "https://crawler.algolia.com/api/1/crawlers/${CRAWLER_ID}/reindex"
 
   merge-to-develop:
     needs: deploy


### PR DESCRIPTION
## Changes
The `Deploy to prod (AWS S3)` workflow has been extended.
After prod deploy, search is reindexed only once Amplify has actually finished serving the new files.
- `deploy` still uploads to S3 and starts the Amplify deployment. It now exposes the Amplify `job_id` as a job output.
- Added `wait-amplify`: polls the Amplify job every 15 seconds until `SUCCEED`, for up to 15 minutes (fails on `FAILED` / `CANCELLED` / timeout).
- Added `start-algolia-crawler`: depends on `wait-amplify` and calls the Algolia Crawler reindex API. `continue-on-error` is set so a crawler error is visible but does not fail the workflow.
- `merge-to-develop` is unchanged: it still depends only on `deploy`.

## Links
[EPMRPP-118655](https://jiraeu.epam.com/browse/EPMRPP-118655)

#### Algolia API docs
[Crawler API](https://www.algolia.com/doc/rest-api/crawler)
[Start a crawl](https://www.algolia.com/doc/rest-api/crawler/start-reindex)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Production deployments now report deployment progress and wait for completion before proceeding.
  * Search indexing is automatically requested after a successful deployment.

* **Bug Fixes**
  * Deployment failures and timeouts are now detected and reported instead of being silently overlooked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->