### PR TITLE
EPMRPP-118506 || Update script for proper formatting of AUTO Release Notes. Part 3

### DIFF
--- a/scripts/release-utils.js
+++ b/scripts/release-utils.js
@@ -194,10 +194,87 @@ function normalizeReportPortalLinks(text) {
   );
 }
 
+function isFenceLine(line) {
+  return /^\s*```/.test(line);
+}
+
+function isStructuralLine(line) {
+  const t = line.trim();
+  if (t === '') return true;
+  if (/^#{1,6}\s/.test(t)) return true;
+  if (/^[*+-]\s+/.test(t)) return true;
+  if (/^\d+[.)]\s+/.test(t)) return true;
+  if (/^\|.*\|$/.test(t)) return true;
+  if (/^>/.test(t)) return true;
+  if (/^([*_-])\1{2,}$/.test(t)) return true;
+  return false;
+}
+
+function normalizeHeadings(lines) {
+  let inCodeBlock = false;
+
+  return lines.map((line) => {
+    if (isFenceLine(line)) {
+      inCodeBlock = !inCodeBlock;
+      return line;
+    }
+    if (inCodeBlock) return line;
+
+    const match = line.match(/^(#{1,6})(\s+)(.*)$/);
+    if (!match) return line;
+
+    let [, hashes, spacing, rest] = match;
+    rest = rest.replace(/\*\*(.*?)\*\*/g, '$1');
+    if (hashes.length === 1) hashes = '##';
+
+    return `${hashes}${spacing}${rest}`;
+  });
+}
+
+function convertListMarkers(lines) {
+  let inCodeBlock = false;
+
+  return lines.map((line) => {
+    if (isFenceLine(line)) {
+      inCodeBlock = !inCodeBlock;
+      return line;
+    }
+    if (inCodeBlock) return line;
+
+    // Skip horizontal rules such as "---" so they aren't mistaken for list items.
+    if (/^\s*-{3,}\s*$/.test(line)) return line;
+
+    return line.replace(/^(\s*)-(\s+)/, '$1*$2');
+  });
+}
+
+function insertLineBreaks(lines) {
+  let inCodeBlock = false;
+
+  return lines.map((line, index) => {
+    if (isFenceLine(line)) {
+      inCodeBlock = !inCodeBlock;
+      return line;
+    }
+    if (inCodeBlock) return line;
+    if (isStructuralLine(line)) return line;
+    if (/(\s{2}|<br\s*\/?>)$/.test(line)) return line;
+
+    const nextLine = lines[index + 1];
+    if (nextLine === undefined || isStructuralLine(nextLine)) return line;
+
+    return `${line.replace(/\s+$/, '')}<br />`;
+  });
+}
+
 function transformBody(body) {
   let result = body;
 
   result = result.replace(/\r\n/g, '\n');
+
+  result = normalizeHeadings(result.split('\n')).join('\n');
+  result = convertListMarkers(result.split('\n')).join('\n');
+  result = insertLineBreaks(result.split('\n')).join('\n');
 
   result = result.replace(/<img\b[^>]*>/gi, (tag) => {
     const srcMatch = tag.match(/src="([^"]+)"/i);

--- a/scripts/release-utils.js
+++ b/scripts/release-utils.js
@@ -194,8 +194,24 @@ function normalizeReportPortalLinks(text) {
   );
 }
 
-function isFenceLine(line) {
-  return /^\s*```/.test(line);
+function matchFence(line) {
+  // Matches both ``` and ~~~ style fences, capturing the marker character and length
+  // so a closing fence can be required to use the same character and be at least as long.
+  const match = line.match(/^\s*(`{3,}|~{3,})/);
+  if (!match) return null;
+  const marker = match[1];
+  return { char: marker[0], length: marker.length };
+}
+
+function isIndentedCodeLine(line) {
+  // CommonMark: 4+ spaces or a tab, indented code (can't interrupt a paragraph).
+  return /^(\t| {4,})\S/.test(line);
+}
+
+function isThematicBreak(line) {
+  // CommonMark thematic break: 3+ of the same -, *, or _ character, optionally
+  // separated by spaces, e.g. "---", "***", "- - -".
+  return /^\s{0,3}([-*_])( *\1){2,} *$/.test(line);
 }
 
 function isStructuralLine(line) {
@@ -206,19 +222,52 @@ function isStructuralLine(line) {
   if (/^\d+[.)]\s+/.test(t)) return true;
   if (/^\|.*\|$/.test(t)) return true;
   if (/^>/.test(t)) return true;
-  if (/^([*_-])\1{2,}$/.test(t)) return true;
+  if (isThematicBreak(t)) return true;
   return false;
 }
 
+// Tracks whether each line, in order, sits inside a fenced or indented code
+// block, so the transforms below can leave that content untouched.
+function createCodeBlockTracker() {
+  let openFence = null; // { char, length } of the fence currently open, or null
+  let inIndentedCode = false;
+  let afterBlank = true;
+
+  return function isProtected(line) {
+    const fence = matchFence(line);
+    if (fence) {
+      const closesOpenFence =
+        openFence && fence.char === openFence.char && fence.length >= openFence.length;
+      openFence = closesOpenFence ? null : (openFence || fence);
+      afterBlank = false;
+      return true;
+    }
+    if (openFence) {
+      afterBlank = line.trim() === '';
+      return true;
+    }
+
+    if (line.trim() === '') {
+      afterBlank = true;
+      return inIndentedCode;
+    }
+
+    if (inIndentedCode) {
+      if (!isIndentedCodeLine(line)) inIndentedCode = false;
+    } else if (isIndentedCodeLine(line) && afterBlank) {
+      inIndentedCode = true;
+    }
+    afterBlank = false;
+
+    return inIndentedCode;
+  };
+}
+
 function normalizeHeadings(lines) {
-  let inCodeBlock = false;
+  const isProtected = createCodeBlockTracker();
 
   return lines.map((line) => {
-    if (isFenceLine(line)) {
-      inCodeBlock = !inCodeBlock;
-      return line;
-    }
-    if (inCodeBlock) return line;
+    if (isProtected(line)) return line;
 
     const match = line.match(/^(#{1,6})(\s+)(.*)$/);
     if (!match) return line;
@@ -232,33 +281,26 @@ function normalizeHeadings(lines) {
 }
 
 function convertListMarkers(lines) {
-  let inCodeBlock = false;
+  const isProtected = createCodeBlockTracker();
 
   return lines.map((line) => {
-    if (isFenceLine(line)) {
-      inCodeBlock = !inCodeBlock;
-      return line;
-    }
-    if (inCodeBlock) return line;
+    if (isProtected(line)) return line;
 
-    // Skip horizontal rules such as "---" so they aren't mistaken for list items.
-    if (/^\s*-{3,}\s*$/.test(line)) return line;
+    // Skip horizontal rules such as "---" or "- - -" so they aren't mistaken for list items.
+    if (isThematicBreak(line)) return line;
 
     return line.replace(/^(\s*)-(\s+)/, '$1*$2');
   });
 }
 
 function insertLineBreaks(lines) {
-  let inCodeBlock = false;
+  const isProtected = createCodeBlockTracker();
 
   return lines.map((line, index) => {
-    if (isFenceLine(line)) {
-      inCodeBlock = !inCodeBlock;
-      return line;
-    }
-    if (inCodeBlock) return line;
+    if (isProtected(line)) return line;
     if (isStructuralLine(line)) return line;
-    if (/(\s{2}|<br\s*\/?>)$/.test(line)) return line;
+    // Already has a hard break: two+ trailing spaces, an explicit <br/>, or a trailing backslash.
+    if (/(\s{2}|<br\s*\/?>|\\)$/.test(line)) return line;
 
     const nextLine = lines[index + 1];
     if (nextLine === undefined || isStructuralLine(nextLine)) return line;


### PR DESCRIPTION
## Description
Extends transformBody in scripts/release-utils.js (used by both sync-releases.js and update-release.js) to fix three formatting issues seen in auto-synced GitHub release notes:

Line breaks — a single newline between two paragraph lines (no blank line) renders fine on GitHub but collapses into one run-on line in Docusaurus. Consecutive plain-text lines now get an explicit 'br' inserted between them.
List markers — unordered list items copied from GitHub (- item) are now converted to * item for consistency with the docs' preferred style.
Subheadings — headings like # 1. **What's new:** (H1, wrapped in bold) are now normalized to a real, non-bold H2 (## 1. What's new:), while genuine nested subheadings (e.g. ### Service-api) are left at their original level.

All three transforms are fence/code-block aware, so fenced (``` and ~~~) and indented (4-space) code samples in release notes are left untouched, and correctly skip horizontal rules, tables, blockquotes, and lists rather than misapplying the line-break logic to them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Release notes now use more consistent heading levels and formatting.
  * List items are rendered with standardized bullet markers.
  * Consecutive lines receive improved spacing for easier reading.
  * Content inside fenced code blocks remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->